### PR TITLE
Check for colon for time when searching for time

### DIFF
--- a/src/google_flight_analysis/flight.py
+++ b/src/google_flight_analysis/flight.py
@@ -105,7 +105,7 @@ class Flight:
 		return self._time_arrive
 
 	def _classify_arg(self, arg):
-		if ('AM' in arg or 'PM' in arg) and len(self._times) < 2:
+		if ('AM' in arg or 'PM' in arg) and len(self._times) < 2 and ':' in arg:
 			# arrival or departure time
 			delta = timedelta(days = 0)
 			if arg[-2] == '+':

--- a/src/google_flight_analysis/scrape.py
+++ b/src/google_flight_analysis/scrape.py
@@ -219,7 +219,7 @@ class _Scrape:
 
 		res3 = res2[start:mid_start] + res2[mid_end:end]
 
-		matches = [i for i, x in enumerate(res3) if len(x) > 2 and ((x[-2] != '+' and (x.endswith('PM') or x.endswith('AM'))) or x[-2] == '+')][::2]
+		matches = [i for i, x in enumerate(res3) if len(x) > 2 and ((x[-2] != '+' and (x.endswith('PM') or x.endswith('AM')) and ':' in x) or x[-2] == '+')][::2]
 		flights = [Flight(self._date_leave, res3[matches[i]:matches[i+1]]) for i in range(len(matches)-1)]
 
 		return flights


### PR DESCRIPTION
![image](https://github.com/celebi-pkg/flight-analysis/assets/68391744/0cb107bc-9474-49d7-8dc0-7d90edd1dffd)

Check for colon when scraping and converting to datetime. Airline LATAM creates a ValueError when we check soley for 'AM' and 'PM'